### PR TITLE
Release and only provide GCS configuration defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.mintel</groupId>
    <artifactId>alfresco-gcs-connector</artifactId>
-   <version>1.0-SNAPSHOT</version>
+   <version>1.0.1</version>
    <name>Alfresco GCS connector</name>
    <description>Alfresco Google Cloud Storage connector</description>
    <packaging>jar</packaging>
@@ -34,7 +34,7 @@
       <acs.debug.port>8888</acs.debug.port>
       <postgres.port>5555</postgres.port>
       <!-- This parameter is only required for those cases in which ACS is not exposed in http://localhost:8080/alfresco (i.e. Windows Docker) -->
-      <test.acs.endpoint.path></test.acs.endpoint.path>
+      <test.acs.endpoint.path />
 
    </properties>
 

--- a/src/main/resources/alfresco/module/alfresco-gcs-connector/alfresco-global.properties
+++ b/src/main/resources/alfresco/module/alfresco-gcs-connector/alfresco-global.properties
@@ -17,33 +17,3 @@ gcs.bucketName.deleted=${gcs.bucketName}
 #path in bucket e.g.: contenstore will store objects in gcs://contenststore/2019/...
 gcs.dir.contentstore=${dir.contentstore}
 gcs.dir.contentstore.deleted=${dir.contentstore.deleted}
-
-dir.cachedcontent=/path/to/cache
-dir.root=/path/to/local
-
-##############################
-# Caching default properties #
-##############################
-
-system.content.caching.cacheOnInbound=true
-system.content.caching.maxUsageMB=4096
-# maxFileSizeMB - 0 means no max file size.
-system.content.caching.maxFileSizeMB=0
-# When the CachingContentStore is about to write a cache file but the disk usage is in excess of panicThresholdPct
-# (default 90%) then the cache file is not written and the cleaner is started (if not already running) in a new thread.
-system.content.caching.panicThresholdPct=90
-# When a cache file has been written that results in cleanThresholdPct (default 80%) of maxUsageBytes
-# being exceeded then the cached content cleaner is invoked (if not already running) in a new thread.
-system.content.caching.cleanThresholdPct=80
-# An aggressive cleaner is run till the targetUsagePct (default 70%) of maxUsageBytes is achieved
-system.content.caching.targetUsagePct=70
-# Threshold in seconds indicating a minimal gap between normal cleanup starts
-system.content.caching.normalCleanThresholdSec=0
-system.content.caching.minFileAgeInMillis=2000
-system.content.caching.maxDeleteWatchCount=1
-# Clean up every day at 3 am
-system.content.caching.contentCleanup.cronExpression=0 0 3 * * ?
-system.content.caching.timeToLiveSeconds=0
-system.content.caching.timeToIdleSeconds=60
-system.content.caching.maxElementsInMemory=5000
-system.content.caching.maxElementsOnDisk=10000


### PR DESCRIPTION
I made a 1.0.1 release and removed the dir.root as that was somehow picked up from this module rather than the the shared/classes/alfresco-global.properties one.