### PR TITLE
Avoid making an additional expensive call to Google Storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.mintel</groupId>
    <artifactId>alfresco-gcs-connector</artifactId>
-   <version>1.0.1</version>
+   <version>1.0.2-SNAPSHOT</version>
    <name>Alfresco GCS connector</name>
    <description>Alfresco Google Cloud Storage connector</description>
    <packaging>jar</packaging>

--- a/src/main/java/com/mintel/gcs/GCSContentReader.java
+++ b/src/main/java/com/mintel/gcs/GCSContentReader.java
@@ -65,7 +65,7 @@ public class GCSContentReader extends AbstractContentReader
     public boolean exists()
     {
         Blob metadata = getMetadata();
-        return metadata != null && metadata.exists();
+        return metadata != null;
     }
 
     /**
@@ -123,7 +123,7 @@ public class GCSContentReader extends AbstractContentReader
 
     /**
      * Gets a blob with just the required metadata (size and last modified date)
-     * 
+     *
      * @return Blob containing only these fields
      */
     private Blob getMetadata()


### PR DESCRIPTION
Is it worthwhile for us to have this change? It would speed up some requests bij 33% e.g. when reindexing.

The reasoning behind this is that we do 3 calls now that each take between 25 and 155ms
- metadata call to fetch size and modified date
- exists call to check if it exists
- download call
I removed the exists (2) call, and assume it exists when I can fetch the metadata.

I tested it against the integration-tests in the project and also the delete-job on the servers.

I think when we move to Kubernetes, it will be faster anyway as we're closer to GCS and round trips would be faster.